### PR TITLE
Update CONTRIBUTING.md to account for new module path

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,6 +47,7 @@ As releases of `go-ethereum` are made, we follow a consistent/predictable proces
   - Triple check that the `go.mod` path and all `.go` import paths are replaced.
     - Failure to do so may result in `medusa` failing to compile later on.
   - Commit this refactor with the commit message `DO NOT INCLUDE IN PATCH SET: Refactor module path` or similar, for clarity.
+    - Only commit `medusa-geth` changes, not changes to any submodules that were inadvertently refactored in the process.
   
 ### Linking the latest `medusa-geth` branch to `medusa`
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,8 +46,10 @@ As releases of `go-ethereum` are made, we follow a consistent/predictable proces
     - **Important**: JetBrains GoLand and Visual Studio Code load find-and-replace results asynchronously, so replacing all before it is done loading may not actually replace all!
   - Triple check that the `go.mod` path and all `.go` import paths are replaced.
     - Failure to do so may result in `medusa` failing to compile later on.
+  - Commit this refactor with the commit message `DO NOT INCLUDE IN PATCH SET: Refactor module path` or similar, for clarity.
   
 ### Linking the latest `medusa-geth` branch to `medusa`
+
 Note that `medusa-geth` is linked to `medusa` through a [pseudo-version](https://go.dev/ref/mod#pseudo-versions), not 
 through a traditional release tag. A pseudo-version is a specially formatted pre-release version that encodes 
 information about a specific revision in a version control repository. To link the new `medusa-geth` forked branch, 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ As releases of `go-ethereum` are made, we follow a consistent/predictable proces
 
   - Clone the `go-ethereum` repository at the exact commit hash for the release you wish to fork.
   - Add this repository as a remote (tracked repository) and remove the original `go-ethereum` repository as a remote.
-  - Create a new branch at your current position, name if `v<version number`, like the rest of `medusa-geth`'s releases (e.g. `v1.11.1`).
+  - Create a new branch at your current position, name it `v<version number`, like the rest of `medusa-geth`'s releases (e.g. `v1.11.1`).
   - Delete all release tags pulled locally to your machine using `git tag -d $(git tag -l)` (we do not want to push `go-ethereum` release tags to this repository).
   - Your local repository should now point to this repository as a remote, have no release tags locally, and be on a branch with a name that is consistent with our release version number. 
   - You can finally push your changes to the remote.


### PR DESCRIPTION
As seen in the https://github.com/crytic/medusa-geth/tree/v1.14.6-new-module-path branch, we now refactor the `go-ethereum` module path to `medusa-geth` properly. This should solve `medusa`'s issue here: https://github.com/crytic/medusa/pull/584

This PR aims to update the CONTRIBUTING.md on the `main` branch of this repo in accordance with the `medusa` PR linked above. They should be merged together.