### PR TITLE
Fix SetCode aliasing of input bytecode

### DIFF
--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -551,7 +551,7 @@ func (s *stateObject) CodeSize() int {
 func (s *stateObject) SetCode(codeHash common.Hash, code []byte) (prev []byte) {
 	prev = slices.Clone(s.code)
 	s.db.journal.setCode(s.address, prev)
-	s.setCode(codeHash, code)
+	s.setCode(codeHash, slices.Clone(code))
 	return prev
 }
 

--- a/core/state/state_test.go
+++ b/core/state/state_test.go
@@ -134,6 +134,25 @@ func TestIterativeDump(t *testing.T) {
 	}
 }
 
+func TestSetCodeClonesInput(t *testing.T) {
+	sdb, _ := New(types.EmptyRootHash, NewDatabaseForTesting())
+	addr := common.BytesToAddress([]byte{0x01})
+
+	code := []byte{0x61, 0x00, 0x0f, 0x57}
+	wantCode := bytes.Clone(code)
+	wantHash := crypto.Keccak256Hash(wantCode)
+
+	sdb.SetCode(addr, code)
+	code[2] = 0xa1
+
+	if got := sdb.GetCode(addr); !bytes.Equal(got, wantCode) {
+		t.Fatalf("stored code should not alias caller buffer: got %x want %x", got, wantCode)
+	}
+	if got := sdb.GetCodeHash(addr); got != wantHash {
+		t.Fatalf("stored code hash mismatch: got %s want %s", got.Hex(), wantHash.Hex())
+	}
+}
+
 func TestNull(t *testing.T) {
 	s := newStateEnv()
 	address := common.HexToAddress("0x823140710bf13990e4500136726d8b55")


### PR DESCRIPTION
This fixes a byte-slice aliasing bug in `core/state/state_object.go`.

Problem:
`SetCode` stored the caller-provided byte slice by reference instead of cloning it before storing it in state. If that slice was later mutated or reused, etched runtime bytecode could be corrupted and execution could diverge from normally deployed contracts.

Fix:
Clone the input byte slice before storing it in state.

Validation:
- Added a focused regression test: `TestSetCodeClonesInput`
- Verified with:
  `go test ./core/state -run TestSetCodeClonesInput -count=1`
- Also verified against a real Medusa repro where `vm.etch` execution diverged from the same runtime deployed normally

Related issue:
- https://github.com/crytic/medusa/issues/827